### PR TITLE
Add actor.ini file from docs

### DIFF
--- a/actor.ini
+++ b/actor.ini
@@ -1,0 +1,9 @@
+[actor]
+name = fastqc_router
+token = True
+
+[docker]
+dockerfile = Dockerfile
+namespace = jurrutia
+repo = fastqc_router
+tag = 0.2


### PR DESCRIPTION
actor.ini file was missing. Add actor.ini from the TACC 2020 Summer
Institute docs at https://github.com/JoshuaUrrutia/tacc-reproducible-automation/blob/232b617c0976b4e1987d98bfd531c93bac93a091/docs/assets/actor.ini#L1
